### PR TITLE
Add custom stream error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ with the following arguments:
     (b) a data retrieval function which takes a location, a logger and a callback as arguments,
     (c) the response object, and
     (d) a logger object (optional)
+    (e) an error handling function taking an error object as only argument (optional, default is to call response.connection.destroy() on error)
 
 Example
 ---------------


### PR DESCRIPTION
Provide an optional error handler function as the last parameter to
readySetStream(), called when an error happens on the way to stream
output with the error object as parameter. The idea is to allow more
specific error handling than the default behavior.

The default error handler if none is provided calls destroy() on the
connection object in the response.